### PR TITLE
Guard calls to getExternalStorage for >API29, move to getFilesDirectory

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/App.java
+++ b/app/src/main/java/com/door43/translationstudio/App.java
@@ -483,6 +483,8 @@ public class App extends Application {
             } else {
                 dir = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), PUBLIC_DATA_DIR);
             }
+        } else if(Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+            dir = new File(context().getExternalFilesDir(null), Environment.DIRECTORY_DOWNLOADS);
         } else {
             dir = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), PUBLIC_DATA_DIR);
         }
@@ -600,14 +602,17 @@ public class App extends Application {
      */
     public static File publicDir() {
         String state = Environment.getExternalStorageState();
-        File sd = Environment.getExternalStorageDirectory();
-        File dir;
+        File dir = new File(Environment.getDataDirectory(), PUBLIC_DATA_DIR);
 
-        if(Environment.MEDIA_MOUNTED.equals(state) && sd.canWrite()) {
-            dir = new File(sd, PUBLIC_DATA_DIR);
+        if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+            File sd = Environment.getExternalStorageDirectory();
+            if (Environment.MEDIA_MOUNTED.equals(state) && sd.canWrite()) {
+                dir = new File(sd, PUBLIC_DATA_DIR);
+            } else {
+                Log.w(TAG, "External storage was missing. Falling back to data dir.");
+            }
         } else {
-            Log.w(TAG, "External storage was missing. Falling back to data dir.");
-            dir = new File(Environment.getDataDirectory(), PUBLIC_DATA_DIR);
+            Log.i(TAG, "SDK Version is Android Q or higher. Falling back to data dir.");
         }
 
         if(!dir.exists()) {

--- a/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
@@ -294,7 +294,7 @@ public class FileChooserActivity extends BaseActivity {
         if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
             storagePath = Environment.getExternalStorageDirectory();
         } else {
-            storagePath = new File(App.context().getFilesDir(), HOME_DIRECTORY);
+            storagePath = new File(App.context().getExternalFilesDir(null), HOME_DIRECTORY);
         }
         showFileFolder(storagePath);
     }

--- a/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import androidx.documentfile.provider.DocumentFile;
@@ -41,6 +42,7 @@ public class FileChooserActivity extends BaseActivity {
     public static final String FILE_PATH_KEY = "file_path";
     public static final String SD_CARD_TYPE = "sd_card";
     public static final String INTERNAL_TYPE = "internal";
+    public static final String HOME_DIRECTORY = "Home";
 
     private ImageButton mUpButton;
     private Button mInternalButton;
@@ -266,11 +268,13 @@ public class FileChooserActivity extends BaseActivity {
             File sdCardFolder = SdUtils.getSdCardDirectory();
             if( (sdCardFolder != null) && SdUtils.isSdCardAccessableInMode(mWriteAccess) ) {
                 if (sdCardFolder.isDirectory() && sdCardFolder.exists() && sdCardFolder.canRead()) {
-                    File storagePath = Environment.getExternalStorageDirectory();
-                    if(!sdCardFolder.equals(storagePath)) { // make sure it doesn't reflect back to internal memory
-                        sdCardFound = true;
-                        sdCardHaveAccess = true;
-                        showFileFolder(sdCardFolder);
+                    if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) { // Android Q+ cannot write to the External Storage Directory
+                        File storagePath = Environment.getExternalStorageDirectory();
+                        if (!sdCardFolder.equals(storagePath)) { // make sure it doesn't reflect back to internal memory
+                            sdCardFound = true;
+                            sdCardHaveAccess = true;
+                            showFileFolder(sdCardFolder);
+                        }
                     }
                 }
             }
@@ -286,7 +290,12 @@ public class FileChooserActivity extends BaseActivity {
      * will display file list for external storage directory
      */
     private void showFileFolderFromInternalMemory() {
-        File storagePath = Environment.getExternalStorageDirectory();
+        File storagePath;
+        if(Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+            storagePath = Environment.getExternalStorageDirectory();
+        } else {
+            storagePath = new File(App.context().getFilesDir(), HOME_DIRECTORY);
+        }
         showFileFolder(storagePath);
     }
 


### PR DESCRIPTION
Tries to handle support for Android 10+ storage access.

Fixes # .

Changes in this pull request:
-
-
-